### PR TITLE
Reordered includes for no-worker-app mode

### DIFF
--- a/src/MiniDungeon.c
+++ b/src/MiniDungeon.c
@@ -16,7 +16,7 @@
 	 
 static bool hasFocus = true;
 
-bool HasFocus(void)
+int HasFocus(void)
 {
 	return hasFocus;
 }

--- a/src/MiniDungeon.h
+++ b/src/MiniDungeon.h
@@ -59,4 +59,4 @@
 #define ALLOW_WORKER_APP_LISTENING 1
 
 void ResetGame(void);
-bool HasFocus(void);
+int HasFocus(void);

--- a/src/Worker.c
+++ b/src/Worker.c
@@ -1,12 +1,13 @@
+
+#include "../src/MiniDungeon.h"
+#ifdef BUILD_WORKER_FILES
 #include <pebble_worker.h>
 
 #include "../src/Events.h"
-#include "../src/MiniDungeon.h"
 #include "../src/Utils.h"
 #include "../src/WorkerControl.h"
 #include "Worker_Persistence.h"
 
-#ifdef BUILD_WORKER_FILES
 
 void SendMessageToApp(uint8_t type, uint16_t data0, uint16_t data1, uint16_t data2)
 {

--- a/src/Worker_Events.c
+++ b/src/Worker_Events.c
@@ -1,7 +1,7 @@
-#include <pebble_worker.h>
 #include "MiniDungeon.h"
 
 #ifdef BUILD_WORKER_FILES
+#include <pebble_worker.h>
 // ../src/Events.c holds the probablities for events. 
 // This way we only have to write it once.
 #include "../src/Events.c"

--- a/src/Worker_Persistence.c
+++ b/src/Worker_Persistence.c
@@ -1,10 +1,11 @@
-#include <pebble_worker.h>
 
 #include "MiniDungeon.h"
+#ifdef BUILD_WORKER_FILES
+#include <pebble_worker.h>
+
 #include "../src/Persistence.h"
 #include "Worker_Persistence.h"
 
-#ifdef BUILD_WORKER_FILES
 
 static bool closedInBattle = false;
 static bool workerCanLaunch = false;

--- a/src/Worker_Persistence.h
+++ b/src/Worker_Persistence.h
@@ -1,4 +1,7 @@
 #pragma once
+#include "MiniDungeon.h"
+
+#ifdef BUILD_WORKER_FILES
 #include <pebble_worker.h>
 
 bool LoadWorkerData(void);
@@ -6,3 +9,4 @@ bool GetWorkerCanLaunch(void);
 void SetWorkerCanLaunch(bool enable);
 bool GetClosedInBattle(void);
 void SetClosedInBattle(bool enable);
+#endif


### PR DESCRIPTION
It seems that if there are files in src which include pebble_worker.h, you cannot push to the watch.